### PR TITLE
Bail if there is no token before making request

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -16,6 +16,10 @@ function escape(str) {
 
 function json(url) {
   return new Promise((resolve, reject) => {
+    if (!process.env['GITHUB_TOKEN']) {
+      return reject(new Error('GITHUB_TOKEN is not defined'))
+    }
+
     const req = request(url, {
       headers: {
         'User-Agent': `nodejs ${process.version}`,


### PR DESCRIPTION
This will make people less confused when they run the script locally and it will generate files indicating that we have no custom element repos.