### PR TITLE
Link to examples, if available

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -71,12 +71,16 @@ We have ${repos.length} open source custom elements:
 for (const repo of repos) {
   bowerJson.dependencies[repo.name] = repo.full_name
   packageJson.dependencies[`@${repo.full_name}`] = '*'
+  let exampleLink = '';
+  if (repo.homepage) {
+    exampleLink = ` | [Example](${repo.homepage})`
+  }
   readme += `
 ### [${escape(repo.full_name)}](${repo.html_url})
 
 ${escape(repo.description)}
 
-[Link](${repo.html_url})
+[Repository](${repo.html_url})${exampleLink}
 `
 }
 readme += readFileSync('readme.tail.md', 'utf-8')


### PR DESCRIPTION
When I'm researching a new web component the first thing I look for is a live example.

It looks like the GitHub repositories currently tagged with `custom-element` all use the homepage field to link to their examples.

This change exposes those examples in the README.